### PR TITLE
DEP: Add support for py3.11

### DIFF
--- a/.github/workflows/release_arm.yml
+++ b/.github/workflows/release_arm.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release_manylinux.yml
+++ b/.github/workflows/release_manylinux.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest]
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ classifier = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Rust",
 ]
 


### PR DESCRIPTION
Hello,

thank you very much for this library.

I have Python 3.11 locally and installing it from pip fails because sportgems wheel for 3.11 is not available.

Not sure if `python3.11` also needs to be added to the [`Dockerfile`](https://github.com/fgebhart/sportgems/blob/8b490e27712b17081fc18ed1a9232db8e17d1ff3/Dockerfile#L25)?